### PR TITLE
Bugfixes

### DIFF
--- a/LambTracker_V2/src/com/weyr_associates/lambtracker/DatabaseHandler.java
+++ b/LambTracker_V2/src/com/weyr_associates/lambtracker/DatabaseHandler.java
@@ -592,6 +592,7 @@ public class DatabaseHandler extends SQLiteOpenHelper
 			    out = new FileOutputStream(dst);
 			} catch (FileNotFoundException e) {
 				Log.i("DBH", "Output database file not found " + dst);
+				in.close();
 				return;
 			}
 

--- a/LambTracker_V2/src/com/weyr_associates/lambtracker/DatabaseHandler.java
+++ b/LambTracker_V2/src/com/weyr_associates/lambtracker/DatabaseHandler.java
@@ -259,12 +259,19 @@ public class DatabaseHandler extends SQLiteOpenHelper
      * @return
      */
     public String getStr( int colIndex )
-    	{
-    	if( currentCursor != null )
-    		return currentCursor.getString(colIndex);
-    	
+    {
+    	if( currentCursor != null ) {
+    		String workingString = currentCursor.getString(colIndex);
+    		
+    		// Don't return null string pointers, return empty strings instead.
+    		if (workingString == null)
+    			workingString = "";
+    		
+    		return workingString;
+    	}
     	throw new NullPointerException( "getStr: No cursor from last exec()" );
     	}
+    	
     
     /**
      *
@@ -273,9 +280,15 @@ public class DatabaseHandler extends SQLiteOpenHelper
      */
     public String getStr( String colName  )
     	{
-    	if( currentCursor != null )
-    		return currentCursor.getString( colIndexFromName(colName) );
-    	
+    	if( currentCursor != null ) {
+    		String workingString = currentCursor.getString( colIndexFromName(colName) );
+    		
+    		// Don't return null string pointers, return empty strings instead.
+    		if (workingString == null)
+    			workingString = "";
+    		
+    		return workingString;
+    	}
     	throw new NullPointerException( "getStr: No cursor from last exec()" );
     	}
     

--- a/LambTracker_V2/src/com/weyr_associates/lambtracker/LambingSheep.java
+++ b/LambTracker_V2/src/com/weyr_associates/lambtracker/LambingSheep.java
@@ -335,10 +335,8 @@ public class LambingSheep extends ListActivity
 			        	TV.setText( "This is not a ewe." );
 			        	return;
 					}
-//					if (tempString != "") {		
-////					if (tempString == null || tempString.trim().equals("")) {	
-////					if (tempString.trim().equals("")) {		
-					if (tempString.length() == 0) {		
+
+					if (!tempString.trim().equals("")) {				
 						// This is a removed sheep so set the name to removed, clear out and return
 						clearBtn( v );
 			    		TV = (TextView) findViewById( R.id.sheepnameText );

--- a/LambTracker_V2/src/com/weyr_associates/lambtracker/SheepManagement.java
+++ b/LambTracker_V2/src/com/weyr_associates/lambtracker/SheepManagement.java
@@ -927,23 +927,24 @@ public class SheepManagement extends ListActivity {
 						"inner join units_table on drug_table.meat_withdrawal_units = units_table.id_unitsid where id_drugid = %s", i);
 				Log.i("drug withdrawal ", "db cmd is " + cmd);
 				crsr = dbh.exec(cmd);
-				try {
-				cursor   = ( Cursor ) crsr; 		    	
-				cursor.moveToFirst();
-				//	Initially just set an alert with the number and units from today
-				temp_string = "Slaughter Withdrawal is " + dbh.getStr(1) + " " + dbh.getStr(0) + " from " + mytoday ;
-				Log.i("drug withdrawal ", " new alert is " + temp_string);
-				if (alert_text != null){
-					temp_string = temp_string + "\n" + alert_text;
-//					temp_string = alert_text + "\n" + temp_string;
+				cursor   = ( Cursor ) crsr; 
+				if (cursor.getCount() > 0)
+				{
+					cursor.moveToFirst();
+					//	Initially just set an alert with the number and units from today
+					temp_string = "Slaughter Withdrawal is " + dbh.getStr(1) + " " + dbh.getStr(0) + " from " + mytoday ;
+					Log.i("drug withdrawal ", " new alert is " + temp_string);
+					if (alert_text != null){
+						temp_string = temp_string + "\n" + alert_text;
+	//					temp_string = alert_text + "\n" + temp_string;
+					}
+	
+					cmd = String.format("update sheep_table set alert01 = '%s' where sheep_id =%d ", temp_string, thissheep_id ) ;
+					Log.i("update alerts ", "before cmd " + cmd);
+					dbh.exec( cmd );
+					Log.i("update alerts ", "after cmd " + cmd);
 				}
-
-				cmd = String.format("update sheep_table set alert01 = '%s' where sheep_id =%d ", temp_string, thissheep_id ) ;
-				Log.i("update alerts ", "before cmd " + cmd);
-				dbh.exec( cmd );
-				Log.i("update alerts ", "after cmd " + cmd);
-				}
-				catch (Exception e){
+				else{
 					Toast.makeText(getBaseContext(), "Wormer withdrawal data not set", Toast.LENGTH_SHORT).show();
 					Log.w("Withdrawal: Wormer", "No withdrawal data in db");
 				}
@@ -1060,16 +1061,21 @@ public class SheepManagement extends ListActivity {
 				" sheep_id = %s and drug_id = %s and drug_date_off = '' ",thissheep_id, i);
 				Log.i("remove drug to ", "db cmd is " + cmd);
 				crsr = dbh.exec(cmd);
-				cursor   = ( Cursor ) crsr; 		    	
-				cursor.moveToFirst();
-				id_sheepdrugid = dbh.getInt(0);
-				Log.i("drug record is ", String.valueOf(id_sheepdrugid));
-				Log.i("today is ", mytoday);
-				Log.i("remove drug ", "before update the sheep_drug_table");
-				cmd = String.format("update sheep_drug_table set drug_date_off = '%s', " +
-					"drug_time_off = '%s' where id_sheepdrugid = %s", mytoday, mytime, id_sheepdrugid);
-			  	Log.i("remove drug to ", "db cmd is " + cmd);
-				dbh.exec(cmd);
+				cursor   = ( Cursor ) crsr; 	
+				if (cursor.getCount() > 0) {
+					cursor.moveToFirst();
+					id_sheepdrugid = dbh.getInt(0);
+					Log.i("drug record is ", String.valueOf(id_sheepdrugid));
+					Log.i("today is ", mytoday);
+					Log.i("remove drug ", "before update the sheep_drug_table");
+					cmd = String.format("update sheep_drug_table set drug_date_off = '%s', " +
+						"drug_time_off = '%s' where id_sheepdrugid = %s", mytoday, mytime, id_sheepdrugid);
+				  	Log.i("remove drug to ", "db cmd is " + cmd);
+					dbh.exec(cmd);
+				}else{
+					Toast.makeText(getBaseContext(), "This drug is not eligible for removal", Toast.LENGTH_SHORT).show();
+					Log.w("Removal: Drug", "No removable instance of drug found");
+				}
 				Log.i("add tag ", "after update sheep_drug_table with remove date");					
 			}	
 			

--- a/LambTracker_V2/src/com/weyr_associates/lambtracker/SheepManagement.java
+++ b/LambTracker_V2/src/com/weyr_associates/lambtracker/SheepManagement.java
@@ -41,7 +41,9 @@ import android.widget.Spinner;
 import android.widget.TableLayout;
 import android.widget.TableRow;
 import android.widget.TextView;
+import android.widget.Toast;
 import android.widget.LinearLayout.LayoutParams;
+
 import com.google.zxing.client.android.Intents;
 
 public class SheepManagement extends ListActivity {
@@ -769,21 +771,29 @@ public class SheepManagement extends ListActivity {
 							"inner join units_table on drug_table.meat_withdrawal_units = units_table.id_unitsid where id_drugid = %s", i);
 					Log.i("drug withdrawal ", "db cmd is " + cmd);
 					crsr = dbh.exec(cmd);
-					cursor   = ( Cursor ) crsr; 		    	
-					cursor.moveToFirst();
-					//	Initially just set an alert with the number and units from today
-					// 2014-07-27 Removed the time stamp as it's almost impossible to clear the alerts with it in there
-					temp_string = "Slaughter Withdrawal is " + dbh.getStr(1) + " " + dbh.getStr(0) + " from " + mytoday ;
-					Log.i("drug withdrawal ", " new alert is " + temp_string);
-					if (alert_text != null){						
-//						temp_string = alert_text + "\n" + temp_string;
-						// modified to put the new alert on top and add a newline character. 
-						temp_string = temp_string + "\n" + alert_text;
+					cursor   = ( Cursor ) crsr;
+					// If withdrawal data query fails, we can't do this
+					if (cursor.getCount() > 0)
+					{
+						cursor.moveToFirst();
+						//	Initially just set an alert with the number and units from today
+						// 2014-07-27 Removed the time stamp as it's almost impossible to clear the alerts with it in there
+						temp_string = "Slaughter Withdrawal is " + dbh.getStr(1) + " " + dbh.getStr(0) + " from " + mytoday ;
+						Log.i("drug withdrawal ", " new alert is " + temp_string);
+						if (alert_text != null){						
+							//	temp_string = alert_text + "\n" + temp_string;
+							// modified to put the new alert on top and add a newline character. 
+							temp_string = temp_string + "\n" + alert_text;
+						}
+						cmd = String.format("update sheep_table set alert01 = '%s' where sheep_id =%d ", temp_string, thissheep_id ) ;
+						Log.i("update alerts ", "before cmd " + cmd);
+						dbh.exec( cmd );
+						Log.i("update alerts ", "after cmd " + cmd);
 					}
-					cmd = String.format("update sheep_table set alert01 = '%s' where sheep_id =%d ", temp_string, thissheep_id ) ;
-					Log.i("update alerts ", "before cmd " + cmd);
-					dbh.exec( cmd );
-					Log.i("update alerts ", "after cmd " + cmd);
+					else
+					{
+						Toast.makeText(getBaseContext(), "Vaccine withdrawal data not set", Toast.LENGTH_SHORT).show();
+					}
 					// TODO
 					// Consider calculating the actual date/time withdrawal and putting that in instead. 
 		 		}
@@ -934,6 +944,7 @@ public class SheepManagement extends ListActivity {
 				Log.i("update alerts ", "after cmd " + cmd);
 				}
 				catch (Exception e){
+					Toast.makeText(getBaseContext(), "Wormer withdrawal data not set", Toast.LENGTH_SHORT).show();
 					Log.w("Withdrawal: Wormer", "No withdrawal data in db");
 				}
 				// TODO
@@ -984,24 +995,25 @@ public class SheepManagement extends ListActivity {
 							"inner join units_table on drug_table.meat_withdrawal_units = units_table.id_unitsid where id_drugid = %s", i);
 					Log.i("drug withdrawal ", "db cmd is " + cmd);
 					crsr = dbh.exec(cmd);
-					try {
-					cursor   = ( Cursor ) crsr; 		    	
-					cursor.moveToFirst();
-					//	Initially just set an alert with the number and units from today
-					// 2014-07-27 Removed the time stamp as it's almost impossible to clear the alerts with it in there
-					Log.i("today is ", mytoday);
-					temp_string = "Slaughter Withdrawal is " + dbh.getStr(1) + " " + dbh.getStr(0) + " from " + mytoday ;
-					Log.i("drug withdrawal ", " new alert is " + temp_string);
-					if (alert_text != null){
-						temp_string = temp_string + "\n" + alert_text;
-//						temp_string = alert_text + "\n" + temp_string;
+					if (cursor.getCount() > 0) {
+						cursor   = ( Cursor ) crsr; 		    	
+						cursor.moveToFirst();
+						//	Initially just set an alert with the number and units from today
+						// 2014-07-27 Removed the time stamp as it's almost impossible to clear the alerts with it in there
+						Log.i("today is ", mytoday);
+						temp_string = "Slaughter Withdrawal is " + dbh.getStr(1) + " " + dbh.getStr(0) + " from " + mytoday ;
+						Log.i("drug withdrawal ", " new alert is " + temp_string);
+						if (alert_text != null){
+							temp_string = temp_string + "\n" + alert_text;
+	//						temp_string = alert_text + "\n" + temp_string;
+						}
+						cmd = String.format("update sheep_table set alert01 = '%s' where sheep_id =%d ", temp_string, thissheep_id ) ;
+						Log.i("update alerts ", "before cmd " + cmd);
+						dbh.exec( cmd );
+						Log.i("update alerts ", "after cmd " + cmd);
 					}
-					cmd = String.format("update sheep_table set alert01 = '%s' where sheep_id =%d ", temp_string, thissheep_id ) ;
-					Log.i("update alerts ", "before cmd " + cmd);
-					dbh.exec( cmd );
-					Log.i("update alerts ", "after cmd " + cmd);
-					}
-					catch (Exception e){
+					else
+					{
 						Log.w("Withdrawal: Drug", "No withdrawal data in db");
 					}
 					// TODO


### PR DESCRIPTION
LT choked on me doing my pre-lambing vax today, thanks again to failure to fill out withdrawal times - this time for the vaccine, not the wormer.
Anyways I wrapped that and a few other places in SheepManagement where a failure to return any rows will cause a crash, and changed an old try/catch I put in there to an if/else. No point in throwing needless exceptions.

Also had a chuckle about our different practices when I noticed the reason my wormer kept ending up in location 5 - hardcoded as you only use drench wormers. Well, I only use injectable wormers, heh! I always assumed the location box applied to whichever drugs were selected.
Perhaps I should add mouth to the radio buttons and make them apply to wormer location as well?

I have been trying to catch and put in toast notifications where an error may occur due to a malformed database row, to notify users that something is wrong without having to plug in to ADB. Figure this might be a good practice as currently there are too many "random" crashes if a query fails. A new user would be liable to think the program itself is unstable rather than that they have inadequately filled in some data.